### PR TITLE
Correct bootstrap theme for case-sensitive FS

### DIFF
--- a/q_and_a/templates/base.html
+++ b/q_and_a/templates/base.html
@@ -12,7 +12,7 @@
         <link rel="apple-touch-icon" href="apple-touch-icon.png">
 
         {% load bootstrap_themes %}
-        {% bootstrap_styles theme='Readable' type='min.css' %}
+        {% bootstrap_styles theme='readable' type='min.css' %}
 
     </head>
     <body>


### PR DESCRIPTION
Bootstrap theme needs to be 'readable' instead of 'Readable' to work on case-sensitive file systems.
